### PR TITLE
Refactor the deployment script

### DIFF
--- a/deploy/004_deploy_tokens.ts
+++ b/deploy/004_deploy_tokens.ts
@@ -2,7 +2,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { ethers } from "hardhat";
 
 module.exports = async function (hre: HardhatRuntimeEnvironment) { // HardhatRuntimeEnvironment
-  const {deployments, network, getNamedAccounts} = hre;
+  const { deployments, network, getNamedAccounts } = hre;
   const { log } = deployments;
   const [deployer] = await ethers.getSigners();
   const { kovanSideToken, binanceSideToken } = await getNamedAccounts();
@@ -10,43 +10,36 @@ module.exports = async function (hre: HardhatRuntimeEnvironment) { // HardhatRun
   const SwapRBTC = await deployments.get('SwapRBTC');
   const SwapRrbtcProxy = await deployments.get('SwapRbtcProxy');
   const swapContract = new ethers.Contract(SwapRrbtcProxy.address, SwapRBTC.abi, deployer);
-  
-  if(!network.live){
+
+  if (!network.live) {
     return;
   }
 
-  if(kovanSideToken){
-    const containsSideToken = await swapContract.containsSideTokenBtc(kovanSideToken);
-    if(containsSideToken){
-      log('Token with address: ', kovanSideToken, ' already in contract.')
-    }
-    else {
-      await swapContract.addSideTokenBtc(kovanSideToken);
-      if(await swapContract.containsSideTokenBtc(kovanSideToken)){
-        log('Added token with address: ', kovanSideToken)
-      }
-      else{
-        log('Could not add the token with address: ', kovanSideToken)
-      }  
-    } 
+  if (kovanSideToken) {
+    await tryAddTrustedToken(kovanSideToken, 'kovan', swapContract, log);
   }
 
-  if(binanceSideToken){
-    const containsSideToken = await swapContract.containsSideTokenBtc(binanceSideToken);
-    if(containsSideToken){
-      log('Token with address: ', binanceSideToken, ' already in contract.')
-    }
-    else {
-      await swapContract.addSideTokenBtc(binanceSideToken);
-      if(await swapContract.containsSideTokenBtc(binanceSideToken)){
-        log('Added token with address: ', binanceSideToken)
-      }
-      else{
-        log('Could not add the token with address: ', binanceSideToken)
-      }  
-    } 
+  if (binanceSideToken) {
+    await tryAddTrustedToken(binanceSideToken, 'binance', swapContract, log);
   }
 };
 
+async function tryAddTrustedToken(sideToken: string, networkName: string, swapContract: any, log: any) {
+  const containsSideToken = await swapContract.containsSideTokenBtc(sideToken);
+  if (containsSideToken) {
+    log('Token with address:', sideToken, 'for network:', networkName, 'already in contract.')
+  }
+  else {
+    await swapContract.addSideTokenBtc(sideToken);
+    if (await swapContract.containsSideTokenBtc(sideToken)) {
+      log('Added token with address:', sideToken, 'for network:', networkName)
+    }
+    else {
+      log('Could not add the token with address:', sideToken, 'network:', networkName)
+    }
+  }
+}
+
 module.exports.id = 'deploy_AddSideTokensToSwap'; // id required to prevent reexecution
 module.exports.tags = ['AddSideTokenBtcToSwap'];
+


### PR DESCRIPTION
The logic for adding a token is the same for every network. This pr encapsulates the deployment script in a function so it can be reused for any network.